### PR TITLE
Fix Windows installer build and update README with badge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,16 +112,18 @@ jobs:
           VAULTMATE_VERSION: ${{ env.VERSION }}
         run: |
           $version = $env:VAULTMATE_VERSION
-          # Patch version into NSI
-          $nsi = Get-Content installer\vaultmate.nsi -Raw
-          $nsi = $nsi -replace '\$%VAULTMATE_VERSION%', $version
-          Set-Content installer\vaultmate_patched.nsi $nsi
-          # Run makensis from the repo root so relative paths work
-          & "C:\Program Files (x86)\NSIS\makensis.exe" /V2 installer\vaultmate_patched.nsi
-          # Rename output to include version
+          # NSIS reads $%VAULTMATE_VERSION% natively from the process environment.
+          # Run makensis from the repo root so relative paths (Application\dist\...) work.
+          & "C:\Program Files (x86)\NSIS\makensis.exe" /V2 installer\vaultmate.nsi
+          # The OutFile in vaultmate.nsi writes: VaultMate-Setup-${APP_VERSION}-windows.exe
           $out = "VaultMate-Setup-${version}-windows.exe"
-          Move-Item "VaultMate-Setup-${version}-windows.exe" $out -ErrorAction SilentlyContinue
-          Get-ChildItem *.exe
+          if (Test-Path $out) {
+            Write-Host "✅ Installer created: $out"
+          } else {
+            Write-Error "❌ Expected installer not found. Listing .exe files:"
+            Get-ChildItem *.exe
+            exit 1
+          }
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![macOS](https://img.shields.io/badge/macOS-12%2B-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/webtech781/vaultmate-gui/releases/latest)
 [![Firefox](https://img.shields.io/badge/Firefox-Fully%20Tested%20✅-FF7139?style=for-the-badge&logo=firefox&logoColor=white)](https://github.com/webtech781/vaultmate-gui/tree/main/extension-firefox)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green?style=for-the-badge)](LICENSE)
+[![Download on SourceForge](https://a.fsdn.com/con/app/sf-download-button)](https://sourceforge.net/projects/vaultmate-gui/files/latest/download)
 
 VaultMate is a powerful, open-source password manager and **software passkey authenticator** that runs entirely on your local machine. It pairs a Python desktop GUI with a browser extension, giving you secure credential autofill and passkey interception directly in your browser — without ever sending your data anywhere.
 

--- a/installer/vaultmate.nsi
+++ b/installer/vaultmate.nsi
@@ -49,7 +49,7 @@ Section "VaultMate (required)" SecMain
     SetOutPath "$INSTDIR"
 
     ; Copy all files from the PyInstaller dist folder
-    File /r "dist\VaultMate\*.*"
+    File /r "Application\dist\VaultMate\*.*"
 
     ; Write install location to registry
     WriteRegStr HKCU "Software\VaultMate" "InstallDir" "$INSTDIR"


### PR DESCRIPTION
This pull request updates the Windows installer build process, improves the installer script, and adds a SourceForge download badge to the README. The main focus is on simplifying and improving the reliability of the NSIS installer workflow and ensuring the correct application files are packaged.

**Installer workflow improvements:**

* The GitHub Actions workflow in `.github/workflows/release.yml` now lets NSIS read the `VAULTMATE_VERSION` directly from the environment, removing the need to patch the `.nsi` file manually. It also adds better error handling and output verification for the installer build step.

**Installer script fixes:**

* The NSIS script `installer/vaultmate.nsi` now copies application files from `Application\dist\VaultMate\*.*` instead of `dist\VaultMate\*.*`, ensuring the correct files are included in the installer.

**Documentation updates:**

* Added a SourceForge download badge to the `README.md` to provide an additional download option for users.