### PR TITLE
fix(installer): add RemoveFolder for AppMenuFolder to resolve ICE64

### DIFF
--- a/installer/vaultmate.wxs
+++ b/installer/vaultmate.wxs
@@ -86,6 +86,8 @@
                   Icon="VaultMateIco"
                   IconIndex="0"
                   Description="VaultMate Password Manager" />
+        <!-- ICE64: every per-user directory must be in the RemoveFile table -->
+        <RemoveFolder Id="RF_AppMenuFolder" Directory="AppMenuFolder" On="uninstall" />
         <!-- KeyPath via registry (shortcuts cannot be KeyPath directly) -->
         <RegistryValue Root="HKCU"
                        Key="Software\VaultMate"


### PR DESCRIPTION
This pull request makes a minor but important update to the Windows installer configuration for VaultMate to improve compliance with installation best practices.

- Installer compliance:
  * Added a `RemoveFolder` entry for the `AppMenuFolder` to ensure that the per-user application menu directory is properly removed on uninstall, addressing ICE64 validation requirements.