### PR TITLE
ci: allow Publish Release to run on workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
     name: 📦 Publish Release
     needs: [build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
 
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
This pull request makes a small update to the release workflow configuration. The change allows the "Publish Release" job to be triggered not only by tag pushes but also manually via the "workflow_dispatch" event.