### PR TITLE
ci: create git tag in release job when triggered via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,18 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
 
     steps:
+      - uses: actions/checkout@v4
+
+      # When triggered manually, create & push the version tag so
+      # softprops/action-gh-release can find it (it requires a tag).
+      - name: Create git tag (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f "${{ env.VERSION }}"
+          git push origin "${{ env.VERSION }}" --force
+
       - uses: actions/download-artifact@v4
         with:
           path: release-assets
@@ -227,6 +239,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.VERSION }}
           name: "VaultMate ${{ env.VERSION }}"
           body: |
             ## 🔐 VaultMate ${{ env.VERSION }}
@@ -248,3 +261,4 @@ jobs:
           prerelease: false
           fail_on_unmatched_files: false
           files: release-assets/*
+


### PR DESCRIPTION
This pull request updates the GitHub Actions release workflow to improve support for manual releases and ensure the correct tag is used during release creation. The main changes focus on reliably creating and pushing version tags when the workflow is triggered manually, and explicitly specifying the tag for the GitHub Release action.

**Release workflow improvements:**

* Added a step to create and push the git tag when the workflow is triggered via `workflow_dispatch`, ensuring that the required tag exists for the release process.
* Updated the `Create GitHub Release` step to explicitly set the `tag_name` using the `${{ env.VERSION }}` environment variable, making the release process more robust and predictable.

**Other:**

* Minor formatting adjustment at the end of the workflow file.