### PR TITLE
fix(installer): fix empty license RTF, hide terminal window, fix desk…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,12 +97,24 @@ jobs:
       - name: Convert LICENSE to RTF
         shell: pwsh
         run: |
-          $txt = Get-Content LICENSE -Raw
-          $e = $txt -replace '\\','\\' -replace '\{','\{' -replace '\}','\}'
-          $e = $e -replace "`r`n",'\par ' -replace "`n",'\par '
-          "{{\rtf1\ansi\deff0{{\fonttbl{{\f0 Courier New;}}}}\f0\fs18 $e}" |
-            Set-Content LICENSE.rtf -Encoding ASCII
-          Write-Host "✅ LICENSE.rtf created"
+          # Build a well-formed RTF document from the plain-text LICENSE.
+          # Use single-quoted strings so \, { and } are all literal characters.
+          $lines = Get-Content LICENSE
+          $sb    = New-Object System.Text.StringBuilder
+          [void]$sb.AppendLine('{\rtf1\ansi\deff0{\fonttbl{\f0\fnil\fcharset0 Courier New;}}\widowctrl\hyphauto')
+          [void]$sb.AppendLine('\pard\f0\fs18')
+          foreach ($line in $lines) {
+            # RTF-escape the three special characters
+            $esc = $line -replace '\\','\\\\' -replace '\{','\\{' -replace '\}','\\}'
+            [void]$sb.AppendLine("$esc\par")
+          }
+          [void]$sb.Append('}')
+          [System.IO.File]::WriteAllText(
+            (Join-Path $PWD 'LICENSE.rtf'),
+            $sb.ToString(),
+            [System.Text.Encoding]::ASCII
+          )
+          Write-Host "✅ LICENSE.rtf created ($($sb.Length) bytes)"
 
       # ── Compile + Link with WiX → .msi ────────────────────────────────────
       - name: Build MSI

--- a/installer/setup_build.ps1
+++ b/installer/setup_build.ps1
@@ -94,14 +94,17 @@ Log "Build complete."
 # ── 5. Desktop shortcut (if requested) ───────────────────────────────────────
 $exePath = Join-Path $InstallDir "Application\dist\VaultMate\VaultMate.exe"
 if ($WantDesktop -eq "1" -and (Test-Path $exePath)) {
+    # CA runs as SYSTEM — $env:USERPROFILE would point to SYSTEM's profile,
+    # not the real user's Desktop. Use the Public Desktop instead (visible to all users).
+    $desktopPath = [Environment]::GetFolderPath('CommonDesktopDirectory')
     $shell    = New-Object -ComObject WScript.Shell
-    $shortcut = $shell.CreateShortcut("$env:USERPROFILE\Desktop\VaultMate.lnk")
+    $shortcut = $shell.CreateShortcut("$desktopPath\VaultMate.lnk")
     $shortcut.TargetPath       = $exePath
     $shortcut.WorkingDirectory = Split-Path $exePath
     $shortcut.IconLocation     = $exePath
     $shortcut.Description      = "VaultMate Password Manager"
     $shortcut.Save()
-    Log "Desktop shortcut created."
+    Log "Desktop shortcut created at $desktopPath\VaultMate.lnk"
 }
 
 Log "=== VaultMate Setup Helper Finished ==="

--- a/installer/vaultmate.wxs
+++ b/installer/vaultmate.wxs
@@ -172,7 +172,7 @@
     -->
     <CustomAction Id="CA_RunSetup"
                   Directory="INSTALLDIR"
-                  ExeCommand="[SystemFolder]WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;$env:VAULTMATE_CA_DATA='[CustomActionData]'; &amp; '[INSTALLDIR]_setup\setup_build.ps1'&quot;"
+                  ExeCommand="[SystemFolder]WindowsPowerShell\v1.0\powershell.exe -NonInteractive -WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -Command &quot;$env:VAULTMATE_CA_DATA='[CustomActionData]'; &amp; '[INSTALLDIR]_setup\setup_build.ps1'&quot;"
                   Execute="deferred"
                   Impersonate="no"
                   Return="check" />


### PR DESCRIPTION
This pull request makes several improvements to the Windows installer build and setup process, focusing on better handling of the LICENSE file conversion, desktop shortcut creation, and installer execution. The changes enhance robustness, user experience, and maintainability.

**Installer and Setup Improvements:**

* The PowerShell script for converting the `LICENSE` file to RTF was rewritten to build a well-formed RTF document line by line, properly escaping special characters and improving formatting and maintainability.
* The desktop shortcut is now created in the Public Desktop folder (using `CommonDesktopDirectory`) instead of the current user's Desktop, ensuring the shortcut is visible to all users when the installer runs as SYSTEM. The log message was updated to reflect the new shortcut location.
* The WiX installer custom action now launches PowerShell with `-NonInteractive` and `-WindowStyle Hidden` options, preventing unwanted windows and user prompts during installation for a smoother, unattended install experience.